### PR TITLE
import Vue in types

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,3 +1,5 @@
+import Vue from 'vue';
+
 declare module "vue/types/vue" {
   interface Vue {
     /**


### PR DESCRIPTION
Or compilation will fail:

```
Type checking and linting in progress...

  App running at:
  - Local:   http://localhost:8080/ 
  - Network: http://10.0.2.15:8080/

ERROR in /home/hjcao/work/h2ms/h2ms/src/components/compute/Node.vue
48:14 Property '$gemit' does not exist on type 'Node'. Did you mean '$emit'?
    46 | 
    47 |     private nodeClicked() {
  > 48 |         this.$gemit('show-node-detail', this.name);
       |              ^
    49 |     }
    50 | 
    51 | }
ERROR in /home/hjcao/work/h2ms/h2ms/src/views/ComputeNodeArray.vue
35:14 Property '$gon' does not exist on type 'ComputeNodes'. Did you mean '$on'?
    33 | 
    34 |     private mounted() {
  > 35 |         this.$gon('show-node-detail', this.showNodeDetail);
       |              ^
    36 |     }
    37 |     private showNodeDetail(nodename: string) {
    38 |         this.detailNodeName = nodename;
No lint errors found
Version: typescript 3.5.3, tslint 5.18.0
Time: 1172ms
```